### PR TITLE
feat: update Node.js to 24.x and add automated release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [24.x]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
 
       # 依存関係のインストール

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,131 @@
+name: Release Package
+
+# mainブランチにマージされた時、または手動実行時に実行
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version increment type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+# リリース処理に必要な権限
+permissions:
+  contents: write  # git push とリリース作成に必要
+  id-token: write  # npm publish に必要
+
+# 並行実行を防止（複数のリリースが同時実行されないように）
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      # コードをチェックアウト
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0  # 全履歴を取得（リリースノート生成のため）
+
+      # Node.js環境のセットアップ
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      # 依存関係のインストール
+      - name: Install dependencies
+        run: npm ci
+
+      # TypeScriptの型チェック
+      - name: TypeScript type check
+        run: npm run type-check
+
+      # Biomeでコード品質チェック
+      - name: Code quality check
+        run: npm run ci
+
+      # Git設定（npm versionでのコミット用）
+      - name: Configure Git
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+
+      # 現在のバージョンを取得
+      - name: Get current version
+        id: current_version
+        run: |
+          CURRENT_VERSION=$(npm version --json | jq -r '.["ecs-pf"]')
+          echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          echo "Current version: $CURRENT_VERSION"
+
+      # バージョンアップ（patch, minor, major）
+      - name: Bump version
+        id: version_bump
+        run: |
+          # 手動実行時は指定されたタイプを使用、push時はpatchを使用
+          VERSION_TYPE="${{ github.event.inputs.version_type || 'patch' }}"
+          echo "Version type: $VERSION_TYPE"
+
+          # npm versionを実行してバージョンをアップ
+          NEW_VERSION=$(npm version $VERSION_TYPE --no-git-tag-version)
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "New version: $NEW_VERSION"
+
+      # プロジェクトのビルド
+      - name: Build project
+        run: npm run build
+
+      # ビルド結果の確認
+      - name: Verify build output
+        run: |
+          if [ ! -f "dist/cli.js" ]; then
+            echo "❌ Build failed: dist/cli.js not found"
+            exit 1
+          fi
+          echo "✅ Build successful: dist/cli.js exists"
+
+      # 変更をコミットしてプッシュ
+      - name: Commit and push version bump
+        run: |
+          git add package.json
+          git commit -m "chore: bump version to ${{ steps.version_bump.outputs.new_version }}"
+          git push origin main
+
+      # GitHub Releaseを作成
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NEW_VERSION="${{ steps.version_bump.outputs.new_version }}"
+          CURRENT_VERSION="${{ steps.current_version.outputs.current_version }}"
+
+          # タグを作成
+          git tag $NEW_VERSION
+          git push origin $NEW_VERSION
+
+          # リリースを作成（前のバージョンからの変更点を自動生成）
+          gh release create $NEW_VERSION \
+            --target main \
+            --title "Release $NEW_VERSION" \
+            --notes-start-tag $CURRENT_VERSION \
+            --generate-notes
+
+      # npmに公開
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## 📝 概要

このPRでは、GitHub ActionsワークフローのNode.jsバージョンを22.xから24.xに更新し、新しいリリースワークフローを追加しました。

## 🔧 変更内容

### Node.jsバージョン更新
- **ci.yml**: Node.js 22.x → 24.x
- **publish.yml**: Node.js 22.x → 24.x  
- **security.yml**: Node.js 22.x → 24.x

### 新しいリリースワークフロー追加 (`release.yml`)
- **自動実行**: mainブランチにマージされた時にpatchバージョンアップ
- **手動実行**: GitHub画面からpatch/minor/majorを選択可能
- **実行フロー**:
  1. `npm version patch/minor/major` でバージョンアップ
  2. `npm run build` でプロジェクトビルド
  3. `git push` でバージョンアップのコミットをプッシュ
  4. `gh release create` でGitHubリリース作成（自動生成リリースノート付き）
  5. `npm publish` でnpmに公開

## ✨ 機能
- 🔒 並行実行防止（concurrency設定）
- 🛠️ ビルド結果の自動検証
- 📋 前バージョンからの変更点を自動でリリースノートに生成
- 🎯 適切な権限設定（contents: write, id-token: write）

## 🧪 テスト

新しいリリースワークフローは、まず手動実行（`workflow_dispatch`）でのテストを推奨します。

## 📚 関連

- Node.js 24.xへのアップデートにより、最新の機能とセキュリティパッチを利用可能
- 既存の`publish.yml`との重複を避けるため、リリース作成時の動作を確認してください