### PR TITLE
improve: extend port range check to support strings

### DIFF
--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -173,8 +173,8 @@ export async function findAvailablePort(startPort = 8888): Promise<number> {
  * Check if a number is within valid port range (1-65535)
  * This is a simple range check without type conversion
  */
-export function isPortRange(port: number): boolean {
-  return Number.isInteger(port) && port >= 1 && port <= 65535;
+export function isPortRange(port: number | string): boolean {
+  return parsePort(port).success;
 }
 
 /**

--- a/test/unit/validation/port-validation.test.ts
+++ b/test/unit/validation/port-validation.test.ts
@@ -295,27 +295,27 @@ describe("isPortRange", () => {
   });
 });
 
-describe("parsePort", () => {
+describe("isPortRange string", () => {
   it("有効なポート文字列の場合trueを返す", () => {
-    expect(parsePort("1").success).toBe(true);
-    expect(parsePort("80").success).toBe(true);
-    expect(parsePort("443").success).toBe(true);
-    expect(parsePort("8080").success).toBe(true);
-    expect(parsePort("65535").success).toBe(true);
+    expect(isPortRange("1")).toBe(true);
+    expect(isPortRange("80")).toBe(true);
+    expect(isPortRange("443")).toBe(true);
+    expect(isPortRange("8080")).toBe(true);
+    expect(isPortRange("65535")).toBe(true);
   });
 
   it("無効なポート文字列の場合falseを返す", () => {
-    expect(parsePort("0").success).toBe(false);
-    expect(parsePort("-1").success).toBe(false);
-    expect(parsePort("65536").success).toBe(false);
-    expect(parsePort("abc").success).toBe(false);
-    expect(parsePort("80.5").success).toBe(false);
-    expect(parsePort("").success).toBe(false);
-    expect(parsePort(" 80 ").success).toBe(false);
+    expect(isPortRange("0")).toBe(false);
+    expect(isPortRange("-1")).toBe(false);
+    expect(isPortRange("65536")).toBe(false);
+    expect(isPortRange("abc")).toBe(false);
+    expect(isPortRange("80.5")).toBe(false);
+    expect(isPortRange("")).toBe(false);
+    expect(isPortRange(" 80 ")).toBe(false);
   });
 
   it("先頭ゼロを含む文字列も正しく処理する", () => {
-    expect(parsePort("0080").success).toBe(true);
-    expect(parsePort("00001").success).toBe(true);
+    expect(isPortRange("0080")).toBe(true);
+    expect(isPortRange("00001")).toBe(true);
   });
 });


### PR DESCRIPTION
This pull request updates the `isPortRange` function to accept both numbers and strings as input, improving its versatility and simplifying related test cases.

### Updates to `isPortRange` function:

* Modified the `isPortRange` function in `src/utils/validation.ts` to accept a `number | string` input, leveraging `parsePort` for validation instead of direct range checks.

### Test case adjustments:

* Updated test cases in `test/unit/validation/port-validation.test.ts` to validate the behavior of `isPortRange` with string inputs, replacing previous tests for `parsePort`.