### PR TITLE
refactor: clean up unused imports and redundant code

### DIFF
--- a/src/core/selection/rds-selection.ts
+++ b/src/core/selection/rds-selection.ts
@@ -2,10 +2,7 @@ import type { RDSClient } from "@aws-sdk/client-rds";
 import { search } from "@inquirer/prompts";
 import { getRDSInstances } from "../../aws-services.js";
 import { searchRDS } from "../../search.js";
-import {
-  parseDBInstanceIdentifier,
-  parsePort,
-} from "../../types/parsers.js";
+import { parseDBInstanceIdentifier, parsePort } from "../../types/parsers.js";
 import type { RDSInstance, SelectionState } from "../../types.js";
 import { getDefaultPortForEngine, messages } from "../../utils/index.js";
 import { clearLoadingMessage } from "../ui/display-utils.js";

--- a/src/types/parsers.ts
+++ b/src/types/parsers.ts
@@ -1,4 +1,4 @@
-import { type InferIssue, safeParse } from "valibot";
+import { safeParse } from "valibot";
 import { isTaskArnShape } from "../regex.js";
 import {
   type ClusterArn,

--- a/test/unit/validation/port-validation.test.ts
+++ b/test/unit/validation/port-validation.test.ts
@@ -1,6 +1,5 @@
 import * as net from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { parsePort } from "../../../src/types.js";
 import {
   areAllPortsInRange,
   findAvailablePort,


### PR DESCRIPTION
This pull request includes minor changes to clean up imports across multiple files, improving code organization and readability.

### Import cleanup:

* [`src/core/selection/rds-selection.ts`](diffhunk://#diff-bf095ff8ffbe1a5fd0aeb060d9b70ecdd804af88650341725e0f1254f98be3adL5-R5): Consolidated the import of `parseDBInstanceIdentifier` and `parsePort` into a single line for better readability.
* [`src/types/parsers.ts`](diffhunk://#diff-31af0358290944d81860d95f9e296b8012188a05a69793ae56e3ab8ec1cd0a31L1-R1): Removed the unused `InferIssue` type from the `valibot` import to eliminate unnecessary code.
* [`test/unit/validation/port-validation.test.ts`](diffhunk://#diff-35ad7f2664772226c43dbf806743a6bd95a3729ab7fa6204a5c727771bc4ef6fL3): Removed the unused import of `parsePort` to streamline the test file.