### PR TITLE
refactor: unify CLI exec command and simplify registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "scripts": {
     "connect": "npm run build && node dist/cli.js connect",
-    "exec-task": "npm run build && node dist/cli.js exec-task",
+    "exec": "npm run build && node dist/cli.js exec",
     "dev": "npm run build && node dist/cli.js connect",
     "build": "./scripts/build.sh",
     "build:tsc": "npx tsc --project tsconfig.build.json",

--- a/src/programs/connect.ts
+++ b/src/programs/connect.ts
@@ -1,4 +1,3 @@
-import type { Command } from "commander";
 import { safeParse } from "valibot";
 import { connectToRDSWithSimpleUI } from "../aws-port-forward.js";
 import { ConnectOptionsSchema } from "../types.js";
@@ -8,44 +7,32 @@ import {
   messages,
 } from "../utils/index.js";
 
-export function registerConnectCommand(program: Command): void {
-  program
-    .command("connect")
-    .description("Connect to RDS via ECS with interactive UI")
-    .option("-r, --region <region>", "AWS region")
-    .option("-c, --cluster <cluster>", "ECS cluster name")
-    .option("-t, --task <task>", "ECS task ID")
-    .option("--rds <rds>", "RDS instance identifier")
-    .option("--rds-port <port>", "RDS port number")
-    .option("-p, --local-port <port>", "Local port number")
-    .option("--dry-run", "Show commands without execution")
-    .action(async (rawOptions: unknown) => {
-      try {
-        // Validate options using Valibot
-        const { success, issues, output } = safeParse(
-          ConnectOptionsSchema,
-          rawOptions,
-        );
+export async function runConnectCommand(rawOptions: unknown): Promise<void> {
+  try {
+    // Validate options using Valibot
+    const { success, issues, output } = safeParse(
+      ConnectOptionsSchema,
+      rawOptions,
+    );
 
-        if (!success) {
-          displayParsingErrors(issues);
-          process.exit(1);
-        }
+    if (!success) {
+      displayParsingErrors(issues);
+      process.exit(1);
+    }
 
-        // Always use interactive UI
-        await connectToRDSWithSimpleUI(output);
-      } catch (error) {
-        // If error occurs during retry process, error is already displayed, so show brief message
-        if (
-          error instanceof Error &&
-          error.message.includes("maximum retry count")
-        ) {
-          messages.error("Terminating process");
-        } else {
-          // For unexpected errors, display detailed error screen
-          displayFriendlyError(error);
-        }
-        process.exit(1);
-      }
-    });
+    // Always use interactive UI
+    await connectToRDSWithSimpleUI(output);
+  } catch (error) {
+    // If error occurs during retry process, error is already displayed, so show brief message
+    if (
+      error instanceof Error &&
+      error.message.includes("maximum retry count")
+    ) {
+      messages.error("Terminating process");
+    } else {
+      // For unexpected errors, display detailed error screen
+      displayFriendlyError(error);
+    }
+    process.exit(1);
+  }
 }

--- a/src/programs/exec.ts
+++ b/src/programs/exec.ts
@@ -1,4 +1,3 @@
-import type { Command } from "commander";
 import { safeParse } from "valibot";
 import { execECSTaskWithSimpleUI } from "../aws-exec.js";
 import { ExecOptionsSchema } from "../types.js";
@@ -8,43 +7,32 @@ import {
   messages,
 } from "../utils/index.js";
 
-export function registerExecTaskCommand(program: Command): void {
-  program
-    .command("exec-task")
-    .description("Execute command in ECS task container with interactive UI")
-    .option("-r, --region <region>", "AWS region")
-    .option("-c, --cluster <cluster>", "ECS cluster name")
-    .option("-t, --task <task>", "ECS task ID")
-    .option("--container <container>", "Container name")
-    .option("--command <command>", "Command to execute (default: /bin/bash)")
-    .option("--dry-run", "Show commands without execution")
-    .action(async (rawOptions: unknown) => {
-      try {
-        // Validate options using Valibot
-        const { success, issues, output } = safeParse(
-          ExecOptionsSchema,
-          rawOptions,
-        );
+export async function runExecTaskCommand(rawOptions: unknown): Promise<void> {
+  try {
+    // Validate options using Valibot
+    const { success, issues, output } = safeParse(
+      ExecOptionsSchema,
+      rawOptions,
+    );
 
-        if (!success) {
-          displayParsingErrors(issues);
-          process.exit(1);
-        }
+    if (!success) {
+      displayParsingErrors(issues);
+      process.exit(1);
+    }
 
-        // Always use interactive UI
-        await execECSTaskWithSimpleUI(output);
-      } catch (error) {
-        // If error occurs during retry process, error is already displayed, so show brief message
-        if (
-          error instanceof Error &&
-          error.message.includes("maximum retry count")
-        ) {
-          messages.error("Terminating process");
-        } else {
-          // For unexpected errors, display detailed error screen
-          displayFriendlyError(error);
-        }
-        process.exit(1);
-      }
-    });
+    // Always use interactive UI
+    await execECSTaskWithSimpleUI(output);
+  } catch (error) {
+    // If error occurs during retry process, error is already displayed, so show brief message
+    if (
+      error instanceof Error &&
+      error.message.includes("maximum retry count")
+    ) {
+      messages.error("Terminating process");
+    } else {
+      // For unexpected errors, display detailed error screen
+      displayFriendlyError(error);
+    }
+    process.exit(1);
+  }
 }

--- a/src/programs/index.ts
+++ b/src/programs/index.ts
@@ -1,8 +1,32 @@
 import type { Command } from "commander";
-import { registerConnectCommand } from "./connect.js";
-import { registerExecTaskCommand } from "./exec.js";
 
-export function registerAllCommands(command: Command): void {
-  registerConnectCommand(command);
-  registerExecTaskCommand(command);
+export function registerAllCommands(program: Command): void {
+  program
+    .command("connect")
+    .description("Connect to an AWS RDS instance via ECS Exec")
+    .option("-r, --region <region>", "AWS region")
+    .option("-c, --cluster <cluster>", "ECS cluster name")
+    .option("-t, --task <task>", "ECS task ID")
+    .option("--rds <rds>", "RDS instance identifier")
+    .option("--rds-port <port>", "RDS port number")
+    .option("-p, --local-port <port>", "Local port number")
+    .option("--dry-run", "Show commands without execution")
+    .action(async (rawOptions: unknown) => {
+      const { runConnectCommand } = await import("./connect.js");
+      await runConnectCommand(rawOptions);
+    });
+
+  program
+    .command("exec")
+    .description("Execute a command on an AWS ECS task")
+    .option("-r, --region <region>", "AWS region")
+    .option("-c, --cluster <cluster>", "ECS cluster name")
+    .option("-t, --task <task>", "ECS task ID")
+    .option("--container <container>", "Container name")
+    .option("--command <command>", "Command to execute (default: /bin/bash)")
+    .option("--dry-run", "Show commands without execution")
+    .action(async (rawOptions: unknown) => {
+      const { runExecTaskCommand } = await import("./exec.js");
+      await runExecTaskCommand(rawOptions);
+    });
 }

--- a/test/integration/cli-commands.test.ts
+++ b/test/integration/cli-commands.test.ts
@@ -111,7 +111,7 @@ describe("CLI Commands Integration", () => {
       const output = stdout + stderr;
       expect(output).toContain("Usage:");
       expect(output).toContain("connect");
-      expect(output).toContain("exec-task");
+      expect(output).toContain("exec");
     });
 
     it("should display version with --version flag", async () => {
@@ -143,7 +143,7 @@ describe("CLI Commands Integration", () => {
       const { code, stdout } = await runCLI(["connect", "--help"]);
 
       expect(code).toBe(0);
-      expect(stdout).toContain("Connect to RDS via ECS with interactive UI");
+      expect(stdout).toContain("Connect to an AWS RDS instance via ECS Exec");
       expect(stdout).toContain("--region");
       expect(stdout).toContain("--cluster");
       expect(stdout).toContain("--task");
@@ -233,14 +233,12 @@ describe("CLI Commands Integration", () => {
     });
   });
 
-  describe("exec-task command", () => {
-    it("should show help for exec-task command", async () => {
-      const { code, stdout } = await runCLI(["exec-task", "--help"]);
+  describe("exec command", () => {
+    it("should show help for exec command", async () => {
+      const { code, stdout } = await runCLI(["exec", "--help"]);
 
       expect(code).toBe(0);
-      expect(stdout).toContain(
-        "Execute command in ECS task container with interactive UI",
-      );
+      expect(stdout).toContain("Execute a command on an AWS ECS task");
       expect(stdout).toContain("--region");
       expect(stdout).toContain("--cluster");
       expect(stdout).toContain("--task");
@@ -250,7 +248,7 @@ describe("CLI Commands Integration", () => {
     });
 
     it("should handle missing required parameters with interactive UI", async () => {
-      const { code } = await runCLI(["exec-task"], 2000);
+      const { code } = await runCLI(["exec"], 2000);
 
       // インタラクティブUIモードでは失敗するかタイムアウトするはず
       expect(code === 1 || code === null).toBe(true);
@@ -259,7 +257,7 @@ describe("CLI Commands Integration", () => {
     it("should validate task parameter format", async () => {
       const { code, stdout } = await runCLI(
         [
-          "exec-task",
+          "exec",
           "--region",
           "ap-northeast-1",
           "--cluster",
@@ -281,7 +279,7 @@ describe("CLI Commands Integration", () => {
     it("should validate container parameter format", async () => {
       const { code, stdout } = await runCLI(
         [
-          "exec-task",
+          "exec",
           "--region",
           "ap-northeast-1",
           "--cluster",
@@ -303,7 +301,7 @@ describe("CLI Commands Integration", () => {
     it("should accept valid command parameter", async () => {
       const { code, stdout } = await runCLI(
         [
-          "exec-task",
+          "exec",
           "--region",
           "ap-northeast-1",
           "--cluster",
@@ -335,7 +333,7 @@ describe("CLI Commands Integration", () => {
 
       // 統合後はconnect-uiコマンドは存在しないので、exec-taskでのバリデーションと比較
       const { stdout: execTaskError } = await runCLI(
-        ["exec-task", "--region", ""],
+        ["exec", "--region", ""],
         2000,
       );
 

--- a/test/integration/dry-run.test.ts
+++ b/test/integration/dry-run.test.ts
@@ -75,18 +75,18 @@ describe("Dry Run Integration Tests", () => {
     });
   });
 
-  describe("exec-task command with --dry-run", () => {
-    it("should show help when --dry-run is used with exec-task command", async () => {
-      const result = await runCommand(["exec-task", "--help"]);
+  describe("exec command with --dry-run", () => {
+    it("should show help when --dry-run is used with exec command", async () => {
+      const result = await runCommand(["exec", "--help"]);
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain("--dry-run");
       expect(result.stdout).toContain("Show commands without execution");
     });
 
-    it("should show error for missing required parameters in exec-task dry run", async () => {
+    it("should show error for missing required parameters in exec dry run", async () => {
       const result = await runCommand([
-        "exec-task",
+        "exec",
         "--dry-run",
         "--region",
         "us-east-1",
@@ -101,7 +101,7 @@ describe("Dry Run Integration Tests", () => {
 
     it("should execute dry run successfully with all required parameters", async () => {
       const result = await runCommand([
-        "exec-task",
+        "exec",
         "--dry-run",
         "--region",
         "us-east-1",


### PR DESCRIPTION
This pull request refactors the CLI commands for better consistency and simplifies the code structure. Key changes include renaming the `exec-task` command to `exec`, consolidating command registration logic, and updating related tests to reflect the new naming and structure.

### Command Refactoring and Consolidation:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L25-R25): Renamed the `exec-task` script to `exec` for consistency with the updated command name.
* [`src/programs/index.ts`](diffhunk://#diff-e2ff8040d51db2fc8ca2a6dda53f3bf0f987682fe5a0421a6cb802bfb873edbeL2-R31): Consolidated command registration logic by directly defining the `connect` and `exec` commands within the `registerAllCommands` function, removing the need for separate `registerConnectCommand` and `registerExecTaskCommand` functions.
* `src/programs/connect.ts` and `src/programs/exec.ts`: Refactored the command implementations to use `runConnectCommand` and `runExecTaskCommand` functions, respectively, simplifying their structure. [[1]](diffhunk://#diff-4bffcb750bb2550b9e5928829934f599d9b658e3af8bebcebdf548ed8a14a777L11-R10) [[2]](diffhunk://#diff-04c2bcd9650f75ed187effa8d14682972480e2cd7be121a3b0378f4fdf2b7b11L11-R10)

### Test Updates:

* [`test/integration/cli-commands.test.ts`](diffhunk://#diff-2aa9313eb83ff170cee24cd206c8242ff2fce90a92695d14dbff2f1be248cdd2L114-R114): Updated all references to the `exec-task` command to `exec` in integration tests and adjusted descriptions to match the new naming and functionality. [[1]](diffhunk://#diff-2aa9313eb83ff170cee24cd206c8242ff2fce90a92695d14dbff2f1be248cdd2L114-R114) [[2]](diffhunk://#diff-2aa9313eb83ff170cee24cd206c8242ff2fce90a92695d14dbff2f1be248cdd2L146-R146) [[3]](diffhunk://#diff-2aa9313eb83ff170cee24cd206c8242ff2fce90a92695d14dbff2f1be248cdd2L236-R241) [[4]](diffhunk://#diff-2aa9313eb83ff170cee24cd206c8242ff2fce90a92695d14dbff2f1be248cdd2L253-R251) [[5]](diffhunk://#diff-2aa9313eb83ff170cee24cd206c8242ff2fce90a92695d14dbff2f1be248cdd2L262-R260) [[6]](diffhunk://#diff-2aa9313eb83ff170cee24cd206c8242ff2fce90a92695d14dbff2f1be248cdd2L284-R282) [[7]](diffhunk://#diff-2aa9313eb83ff170cee24cd206c8242ff2fce90a92695d14dbff2f1be248cdd2L306-R304) [[8]](diffhunk://#diff-2aa9313eb83ff170cee24cd206c8242ff2fce90a92695d14dbff2f1be248cdd2L338-R336)
* [`test/integration/dry-run.test.ts`](diffhunk://#diff-b1c0d136979d20a3f042e725530b83fcd693fea64c197582b498707b0e3664d3L78-R89): Modified dry-run tests to reflect the renaming of `exec-task` to `exec`. [[1]](diffhunk://#diff-b1c0d136979d20a3f042e725530b83fcd693fea64c197582b498707b0e3664d3L78-R89) [[2]](diffhunk://#diff-b1c0d136979d20a3f042e725530b83fcd693fea64c197582b498707b0e3664d3L104-R104)


close #15 