### PR TITLE
feat: CHANGELOG.mdの自動管理機能を追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,10 +95,16 @@ jobs:
           fi
           echo "✅ Build successful: dist/cli.js exists"
 
+      # CHANGELOGを更新
+      - name: Update CHANGELOG
+        run: |
+          npm run changelog:update
+          echo "✅ CHANGELOG.md updated"
+
       # 変更をコミットしてプッシュ
       - name: Commit and push version bump
         run: |
-          git add package.json src/version.ts
+          git add package.json src/version.ts CHANGELOG.md
           git commit -m "chore: bump version to ${{ steps.version_bump.outputs.new_version }}"
           git push origin main
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,98 @@
+## [2.2.14](https://github.com/yuyakinjo/aws-portfoward/compare/v2.2.13...v2.2.14) (2025-06-27)
+## [2.2.13](https://github.com/yuyakinjo/aws-portfoward/compare/v2.2.12...v2.2.13) (2025-06-27)
+
+### Bug Fixes
+
+* Unify PortSchema to handle both string and number inputs ([#17](https://github.com/yuyakinjo/aws-portfoward/issues/17)) ([7b7c254](https://github.com/yuyakinjo/aws-portfoward/commit/7b7c2549014d8b61e4455ef46d9f52d3c12027d1)), closes [#210](https://github.com/yuyakinjo/aws-portfoward/issues/210)
+## [2.2.12](https://github.com/yuyakinjo/aws-portfoward/compare/v2.2.11...v2.2.12) (2025-06-25)
+
+### Bug Fixes
+
+* Resolve Biome lint issues and improve type safety ([#14](https://github.com/yuyakinjo/aws-portfoward/issues/14)) ([679f318](https://github.com/yuyakinjo/aws-portfoward/commit/679f318d0b67b68092ae87e21984c1385859652a))
+## [2.2.11](https://github.com/yuyakinjo/aws-portfoward/compare/v2.2.10...v2.2.11) (2025-06-24)
+
+### Features
+
+* Add dry-run mode for connect and exec commands ([#12](https://github.com/yuyakinjo/aws-portfoward/issues/12)) ([2274968](https://github.com/yuyakinjo/aws-portfoward/commit/2274968394b11c3c6d6b25f67921fde1d68718f6)), closes [#184](https://github.com/yuyakinjo/aws-portfoward/issues/184)
+## [2.2.10](https://github.com/yuyakinjo/aws-portfoward/compare/v2.2.9...v2.2.10) (2025-06-24)
+## [2.2.9](https://github.com/yuyakinjo/aws-portfoward/compare/v2.2.8...v2.2.9) (2025-06-24)
+
+### Bug Fixes
+
+* バージョン管理の改善と未使用インポートの削除 ([#10](https://github.com/yuyakinjo/aws-portfoward/issues/10)) ([1f69072](https://github.com/yuyakinjo/aws-portfoward/commit/1f6907293221709ef8ed43201fa7c11e928f09d2))
+## [2.2.8](https://github.com/yuyakinjo/aws-portfoward/compare/v2.2.7...v2.2.8) (2025-06-24)
+
+### Features
+
+* Add ECS execute-command functionality with interactive UI ([#8](https://github.com/yuyakinjo/aws-portfoward/issues/8)) ([7b3d6f5](https://github.com/yuyakinjo/aws-portfoward/commit/7b3d6f5997104d7ca47292b40ebaff82ada469e7))
+## [2.2.7](https://github.com/yuyakinjo/aws-portfoward/compare/v2.2.6...v2.2.7) (2025-06-23)
+
+### Bug Fixes
+
+* use git tag for current version to match tag format with v prefix ([d08a927](https://github.com/yuyakinjo/aws-portfoward/commit/d08a9274dadfdc8ec1a9d09c1c4f1f566b64af40))
+## [2.2.6](https://github.com/yuyakinjo/aws-portfoward/compare/v2.2.5...v2.2.6) (2025-06-23)
+
+### Features
+
+* update Node.js to 24.x and add automated release workflow ([#7](https://github.com/yuyakinjo/aws-portfoward/issues/7)) ([5c2690a](https://github.com/yuyakinjo/aws-portfoward/commit/5c2690adb4817e4031104ee740fcc6a423dc3d0f))
+## [2.2.5](https://github.com/yuyakinjo/aws-portfoward/compare/v2.2.3...v2.2.5) (2025-06-23)
+
+### Features
+
+* Improve version management with TypeScript and support -v flag ([#6](https://github.com/yuyakinjo/aws-portfoward/issues/6)) ([5b7cf18](https://github.com/yuyakinjo/aws-portfoward/commit/5b7cf18a9325d1bb006587c1b17a1cc9fba2c3de))
+## [2.2.3](https://github.com/yuyakinjo/aws-portfoward/compare/v2.2.2...v2.2.3) (2025-06-23)
+## [2.2.2](https://github.com/yuyakinjo/aws-portfoward/compare/v2.2.1...v2.2.2) (2025-06-23)
+## [2.2.1](https://github.com/yuyakinjo/aws-portfoward/compare/v2.2.0...v2.2.1) (2025-06-23)
+
+### Performance Improvements
+
+* Speed up ECS exec capability and target inference ([#5](https://github.com/yuyakinjo/aws-portfoward/issues/5)) ([315b91b](https://github.com/yuyakinjo/aws-portfoward/commit/315b91b1b9ccd7a0734fb8a308f5c3f9d8473649))
+## [2.2.0](https://github.com/yuyakinjo/aws-portfoward/compare/v2.1.0...v2.2.0) (2025-06-21)
+
+### Features
+
+* Modernize UI/UX and add ECS exec filtering v2.2.0 ([#4](https://github.com/yuyakinjo/aws-portfoward/issues/4)) ([860e07f](https://github.com/yuyakinjo/aws-portfoward/commit/860e07f42b89e679c875383fb460a2f48bed1f2e))
+## [2.1.0](https://github.com/yuyakinjo/aws-portfoward/compare/v2.0.1...v2.1.0) (2025-06-21)
+## [2.0.1](https://github.com/yuyakinjo/aws-portfoward/compare/v2.0.0...v2.0.1) (2025-06-21)
+## [2.0.0](https://github.com/yuyakinjo/aws-portfoward/compare/v1.2.0...v2.0.0) (2025-06-21)
+## [1.2.0](https://github.com/yuyakinjo/aws-portfoward/compare/v1.1.3...v1.2.0) (2025-06-20)
+
+### Features
+
+* RDSエンジン情報をprefixに移動 & ポート番号の自動取得機能追加 ([#1](https://github.com/yuyakinjo/aws-portfoward/issues/1)) ([66e1375](https://github.com/yuyakinjo/aws-portfoward/commit/66e1375c8f375118694b10f3e4c39c048bcf5ae0))
+## [1.1.3](https://github.com/yuyakinjo/aws-portfoward/compare/v1.1.2...v1.1.3) (2025-06-20)
+## [1.1.2](https://github.com/yuyakinjo/aws-portfoward/compare/v1.1.1...v1.1.2) (2025-06-20)
+
+### Bug Fixes
+
+* 🔧 Remove --provenance flag for npm publish ([9dba80e](https://github.com/yuyakinjo/aws-portfoward/commit/9dba80ea0c260a10059d7ddb37df4e700c038eff))
+## [1.1.1](https://github.com/yuyakinjo/aws-portfoward/compare/v1.1.0...v1.1.1) (2025-06-20)
+
+### Bug Fixes
+
+* 🔧 Add required permissions for npm publish ([6f5b088](https://github.com/yuyakinjo/aws-portfoward/commit/6f5b0883a2933809e467a9316bf539cf0f232138))
+## [1.1.0](https://github.com/yuyakinjo/aws-portfoward/compare/v1.0.1...v1.1.0) (2025-06-20)
+
+### Features
+
+* 🎉 Setup automated npm publishing ([65f8453](https://github.com/yuyakinjo/aws-portfoward/commit/65f84530a8997a45b1e093b109144c5e73013868))
+* Add CLI options and input validation for connection ([713c19a](https://github.com/yuyakinjo/aws-portfoward/commit/713c19a5a9c11d8bd01112f186d6cf6e87538b76))
+
+### Bug Fixes
+
+* 🗂️ Remove dist/ directory from Git tracking ([908e700](https://github.com/yuyakinjo/aws-portfoward/commit/908e7006b36875074914515684c7e70d6bc3f316))
+* handle user session termination more cleanly ([5a3199d](https://github.com/yuyakinjo/aws-portfoward/commit/5a3199da7ac43915cf87b8f92aa61684e59885f6))
+* lint ([baca864](https://github.com/yuyakinjo/aws-portfoward/commit/baca864390ccd232cb142617e65e27f199b2ce04))
+* Update npm scripts and include dist files for GitHub Actions [skip ci] ([332c4fc](https://github.com/yuyakinjo/aws-portfoward/commit/332c4fcbe813a570873b0ff741de721b7f1fb9ca))
+## [1.0.1](https://github.com/yuyakinjo/aws-portfoward/compare/5cde0c2fe3bb9446cd42ce333fa54ebad3524c69...v1.0.1) (2025-06-20)
+
+### Features
+
+* Adds ECS RDS proxy CLI tool ([54d5e1c](https://github.com/yuyakinjo/aws-portfoward/commit/54d5e1c53ae97d55aa8b56735f90b5d49152625d))
+* Adds ECS to RDS proxy script ([5cde0c2](https://github.com/yuyakinjo/aws-portfoward/commit/5cde0c2fe3bb9446cd42ce333fa54ebad3524c69))
+* Enables Biome formatter in VS Code ([10e7f7a](https://github.com/yuyakinjo/aws-portfoward/commit/10e7f7a43a7a038771ed3e5af883785c95e03083))
+* Implements RDS port forwarding via ECS ([36fb6ac](https://github.com/yuyakinjo/aws-portfoward/commit/36fb6ac05be4405f59fc5539c530f67a69fc187d))
+
+### Bug Fixes
+
+* Updates file extension for import ([c9ca43b](https://github.com/yuyakinjo/aws-portfoward/commit/c9ca43b43abb31c370e1b659cfeff223c31d40bc))

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -6,7 +6,8 @@
 2. **型チェック**: `npm run type-check`
 3. **コード品質チェック**: `npm run ci`
 4. **ビルド**: `npm run build`
-5. **npm公開**: `npm publish --access public`
+5. **CHANGELOG更新**: `npm run changelog:update`
+6. **npm公開**: `npm publish --access public`
 
 #### リリース手順
 
@@ -39,6 +40,16 @@ gh release create v1.1.3(current version) --target main --notes-start-tag v1.1.2
 # - "Generate release notes" をクリック
 # - "Publish release" をクリック
 ```
+
+##### CHANGELOG管理
+
+このプロジェクトでは**CHANGELOG.md**が自動管理されています：
+
+- **自動更新**: リリース時にGitHub Actionsが自動でCHANGELOG.mdを更新
+- **手動更新**: `npm run changelog:update` でいつでも手動更新可能
+- **初期化**: `npm run changelog:init` で初回のCHANGELOG.mdを作成
+
+CHANGELOGは[Conventional Commits](https://www.conventionalcommits.org/)形式のコミットメッセージから自動生成されます。
 
 ##### ⚠️ 重要な注意点
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ecs-pf",
-  "version": "2.2.11",
+  "version": "2.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ecs-pf",
-      "version": "2.2.11",
+      "version": "2.2.14",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-ec2": "^3.830.0",
@@ -30,6 +30,8 @@
         "@types/inquirer": "^9.0.8",
         "@vitest/coverage-v8": "^3.2.4",
         "@vitest/ui": "^3.2.4",
+        "conventional-changelog-cli": "^5.0.0",
+        "conventional-changelog-conventionalcommits": "^9.0.0",
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
@@ -886,6 +888,28 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -1107,6 +1131,32 @@
       ],
       "engines": {
         "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@conventional-changelog/git-client": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-1.0.1.tgz",
+      "integrity": "sha512-PJEqBwAleffCMETaVm/fUgHldzBE35JFk3/9LL6NUA5EXa3qednu+UT6M7E5iBu3zIQZCULYIiZ90fBYHt6xUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/semver": "^7.5.5",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "conventional-commits-filter": "^5.0.0",
+        "conventional-commits-parser": "^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "conventional-commits-filter": {
+          "optional": true
+        },
+        "conventional-commits-parser": {
+          "optional": true
+        }
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1532,6 +1582,16 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@hutson/parse-repository-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-5.0.0.tgz",
+      "integrity": "sha512-e5+YUKENATs1JgYHMzTr2MW/NDcXGfYFAuOQU8gJgF/kEh4EqKgfGrfLI67bMD4tbhZVlkigz/9YYwWcbOFthg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/@inquirer/checkbox": {
@@ -2874,6 +2934,20 @@
         "undici-types": "~7.8.0"
       }
     },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
+      "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/through": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.33.tgz",
@@ -3061,6 +3135,13 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/add-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
+      "integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -3103,6 +3184,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/array-ify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -3252,6 +3340,248 @@
         "node": ">=20"
       }
     },
+    "node_modules/compare-func": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-ify": "^1.0.0",
+        "dot-prop": "^5.1.0"
+      }
+    },
+    "node_modules/conventional-changelog": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-6.0.0.tgz",
+      "integrity": "sha512-tuUH8H/19VjtD9Ig7l6TQRh+Z0Yt0NZ6w/cCkkyzUbGQTnUEmKfGtkC9gGfVgCfOL1Rzno5NgNF4KY8vR+Jo3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "conventional-changelog-angular": "^8.0.0",
+        "conventional-changelog-atom": "^5.0.0",
+        "conventional-changelog-codemirror": "^5.0.0",
+        "conventional-changelog-conventionalcommits": "^8.0.0",
+        "conventional-changelog-core": "^8.0.0",
+        "conventional-changelog-ember": "^5.0.0",
+        "conventional-changelog-eslint": "^6.0.0",
+        "conventional-changelog-express": "^5.0.0",
+        "conventional-changelog-jquery": "^6.0.0",
+        "conventional-changelog-jshint": "^5.0.0",
+        "conventional-changelog-preset-loader": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-angular": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.0.0.tgz",
+      "integrity": "sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-atom": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-5.0.0.tgz",
+      "integrity": "sha512-WfzCaAvSCFPkznnLgLnfacRAzjgqjLUjvf3MftfsJzQdDICqkOOpcMtdJF3wTerxSpv2IAAjX8doM3Vozqle3g==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-cli": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-5.0.0.tgz",
+      "integrity": "sha512-9Y8fucJe18/6ef6ZlyIlT2YQUbczvoQZZuYmDLaGvcSBP+M6h+LAvf7ON7waRxKJemcCII8Yqu5/8HEfskTxJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "add-stream": "^1.0.0",
+        "conventional-changelog": "^6.0.0",
+        "meow": "^13.0.0",
+        "tempfile": "^5.0.0"
+      },
+      "bin": {
+        "conventional-changelog": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-codemirror": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-5.0.0.tgz",
+      "integrity": "sha512-8gsBDI5Y3vrKUCxN6Ue8xr6occZ5nsDEc4C7jO/EovFGozx8uttCAyfhRrvoUAWi2WMm3OmYs+0mPJU7kQdYWQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.0.0.tgz",
+      "integrity": "sha512-5e48V0+DsWvQBEnnbBFhYQwYDzFPXVrakGPP1uSxekDkr5d7YWrmaWsgJpKFR0SkXmxK6qQr9O42uuLb9wpKxA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-core": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-8.0.0.tgz",
+      "integrity": "sha512-EATUx5y9xewpEe10UEGNpbSHRC6cVZgO+hXQjofMqpy+gFIrcGvH3Fl6yk2VFKh7m+ffenup2N7SZJYpyD9evw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hutson/parse-repository-url": "^5.0.0",
+        "add-stream": "^1.0.0",
+        "conventional-changelog-writer": "^8.0.0",
+        "conventional-commits-parser": "^6.0.0",
+        "git-raw-commits": "^5.0.0",
+        "git-semver-tags": "^8.0.0",
+        "hosted-git-info": "^7.0.0",
+        "normalize-package-data": "^6.0.0",
+        "read-package-up": "^11.0.0",
+        "read-pkg": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-ember": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-5.0.0.tgz",
+      "integrity": "sha512-RPflVfm5s4cSO33GH/Ey26oxhiC67akcxSKL8CLRT3kQX2W3dbE19sSOM56iFqUJYEwv9mD9r6k79weWe1urfg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-eslint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-6.0.0.tgz",
+      "integrity": "sha512-eiUyULWjzq+ybPjXwU6NNRflApDWlPEQEHvI8UAItYW/h22RKkMnOAtfCZxMmrcMO1OKUWtcf2MxKYMWe9zJuw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-express": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-5.0.0.tgz",
+      "integrity": "sha512-D8Q6WctPkQpvr2HNCCmwU5GkX22BVHM0r4EW8vN0230TSyS/d6VQJDAxGb84lbg0dFjpO22MwmsikKL++Oo/oQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-jquery": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-6.0.0.tgz",
+      "integrity": "sha512-2kxmVakyehgyrho2ZHBi90v4AHswkGzHuTaoH40bmeNqUt20yEkDOSpw8HlPBfvEQBwGtbE+5HpRwzj6ac2UfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-jshint": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-5.0.0.tgz",
+      "integrity": "sha512-gGNphSb/opc76n2eWaO6ma4/Wqu3tpa2w7i9WYqI6Cs2fncDSI2/ihOfMvXveeTTeld0oFvwMVNV+IYQIk3F3g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-preset-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-5.0.0.tgz",
+      "integrity": "sha512-SetDSntXLk8Jh1NOAl1Gu5uLiCNSYenB5tm0YVeZKePRIgDW9lQImromTwLa3c/Gae298tsgOM+/CYT9XAl0NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-writer": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.1.0.tgz",
+      "integrity": "sha512-dpC440QnORNCO81XYuRRFOLCsjKj4W7tMkUIn3lR6F/FAaJcWLi7iCj6IcEvSQY2zw6VUgwUKd5DEHKEWrpmEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "conventional-commits-filter": "^5.0.0",
+        "handlebars": "^4.7.7",
+        "meow": "^13.0.0",
+        "semver": "^7.5.2"
+      },
+      "bin": {
+        "conventional-changelog-writer": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog/node_modules/conventional-changelog-conventionalcommits": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
+      "integrity": "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-commits-filter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-commits-parser": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.2.0.tgz",
+      "integrity": "sha512-uLnoLeIW4XaoFtH37qEcg/SXMJmKF4vi7V0H2rnPueg+VEtFGA/asSCNTcq4M/GQ6QmlzchAEtOoDTtKqWeHag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3293,6 +3623,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/eastasianwidth": {
@@ -3456,6 +3799,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/find-up-simple": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/flatted": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
@@ -3512,6 +3868,40 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/git-raw-commits": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-5.0.0.tgz",
+      "integrity": "sha512-I2ZXrXeOc0KrCvC7swqtIFXFN+rbjnC7b2T943tvemIOVNl+XP8YnA9UVwqFhzzLClnSA60KR/qEjLpXzs73Qg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@conventional-changelog/git-client": "^1.0.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "git-raw-commits": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/git-semver-tags": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-8.0.0.tgz",
+      "integrity": "sha512-N7YRIklvPH3wYWAR2vysaqGLPRcpwQ0GKdlqTiVN5w1UmCdaeY3K8s6DMKRCh54DDdzyt/OAB6C8jgVtb7Y2Fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@conventional-changelog/git-client": "^1.0.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "git-semver-tags": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -3533,6 +3923,28 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3541,6 +3953,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/html-escaper": {
@@ -3560,6 +3985,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/index-to-position": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.1.0.tgz",
+      "integrity": "sha512-XPdx9Dq4t9Qk1mTMbWONJqU7boCoumEH7fRET37HX5+khDUl3J2W6PdALxhILYlIYx2amlwYcRPp28p0tSiojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/inquirer": {
@@ -3786,6 +4224,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3928,6 +4376,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/meow": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
@@ -3951,6 +4412,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -4008,6 +4479,28 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-package-data": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
     "node_modules/onetime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
@@ -4035,6 +4528,37 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-json/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -4127,6 +4651,70 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/read-package-up": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+      "integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up-simple": "^1.0.0",
+        "read-pkg": "^9.0.0",
+        "type-fest": "^4.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-package-up/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+      "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.3",
+        "normalize-package-data": "^6.0.0",
+        "parse-json": "^8.0.0",
+        "type-fest": "^4.6.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/remeda": {
@@ -4316,6 +4904,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4325,6 +4923,42 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
+      "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -4482,6 +5116,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/temp-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/tempfile": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-5.0.0.tgz",
+      "integrity": "sha512-bX655WZI/F7EoTDw9JvQURqAXiPHi8o8+yFxPF2lWYyz1aHnmMRuXWqL6YB6GmeO0o4DIYWHLgGNi/X64T+X4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "temp-dir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
@@ -4618,12 +5278,39 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/uuid": {
       "version": "9.0.1",
@@ -4650,6 +5337,17 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "node_modules/vite": {
@@ -4855,6 +5553,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "files": [
     "dist/**/*",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "keywords": [
     "aws",
@@ -27,6 +28,9 @@
     "build": "./scripts/build.sh",
     "build:tsc": "npx tsc --project tsconfig.build.json",
     "generate-version": "node scripts/generate-version.mjs",
+    "generate-changelog": "node scripts/generate-changelog.mjs",
+    "changelog:init": "node scripts/generate-changelog.mjs init",
+    "changelog:update": "node scripts/generate-changelog.mjs generate",
     "start": "node dist/cli.js connect",
     "type-check": "tsc --noEmit",
     "test": "npm run type-check && npm run build && npm run test:unit && npm run test:integration",
@@ -36,6 +40,8 @@
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui",
     "prepublishOnly": "npm run check",
+    "preversion": "npm run check && npm run test",
+    "version": "npm run changelog:update && git add CHANGELOG.md",
     "format": "biome format --write",
     "format:check": "biome format",
     "lint": "biome lint --write",
@@ -49,6 +55,8 @@
     "@types/inquirer": "^9.0.8",
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.2.4",
+    "conventional-changelog-cli": "^5.0.0",
+    "conventional-changelog-conventionalcommits": "^9.0.0",
     "vitest": "^3.2.4"
   },
   "peerDependencies": {

--- a/scripts/generate-changelog.mjs
+++ b/scripts/generate-changelog.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+
+/**
+ * CHANGELOG.mdを自動生成するスクリプト
+ * GitHubのリリース情報を基にCHANGELOGを生成します
+ */
+
+const CHANGELOG_FILE = "CHANGELOG.md";
+
+/**
+ * conventional-changelogを使用してCHANGELOGを生成
+ */
+function generateChangelog() {
+  try {
+    console.log("🔄 CHANGELOG.mdを生成中...");
+
+    // conventional-changelogを実行してCHANGELOGを生成
+    execSync(
+      "npx conventional-changelog -p conventionalcommits -i CHANGELOG.md -s -r 0",
+      {
+        encoding: "utf8",
+        cwd: process.cwd(),
+      },
+    );
+
+    console.log("✅ CHANGELOG.mdが正常に生成されました");
+
+    // 生成されたCHANGELOGの内容を確認
+    if (fs.existsSync(CHANGELOG_FILE)) {
+      const content = fs.readFileSync(CHANGELOG_FILE, "utf8");
+      const lines = content.split("\n").slice(0, 10);
+      console.log("\n📄 生成されたCHANGELOG（最初の10行）:");
+      console.log(lines.join("\n"));
+    }
+  } catch (error) {
+    console.error("❌ CHANGELOG生成中にエラーが発生しました:", error.message);
+    process.exit(1);
+  }
+}
+
+/**
+ * 初回のCHANGELOGを作成（ファイルが存在しない場合）
+ */
+function createInitialChangelog() {
+  if (!fs.existsSync(CHANGELOG_FILE)) {
+    console.log("📝 初回のCHANGELOG.mdを作成中...");
+
+    const initialContent = `# Changelog
+
+このファイルは[conventional-changelog](https://github.com/conventional-changelog/conventional-changelog)によって自動生成されています。
+
+すべての重要な変更はこのファイルに記録されます。
+
+このプロジェクトは[Semantic Versioning](https://semver.org/spec/v2.0.0.html)に従っています。
+
+`;
+
+    fs.writeFileSync(CHANGELOG_FILE, initialContent, "utf8");
+    console.log("✅ 初回のCHANGELOG.mdを作成しました");
+  }
+}
+
+/**
+ * メイン処理
+ */
+function main() {
+  const args = process.argv.slice(2);
+  const command = args[0];
+
+  switch (command) {
+    case "init":
+      createInitialChangelog();
+      break;
+    case "generate":
+      generateChangelog();
+      break;
+    default:
+      createInitialChangelog();
+      generateChangelog();
+      break;
+  }
+}
+
+main();


### PR DESCRIPTION
## 概要

このプルリクエストでは、CHANGELOG.mdの自動管理機能を追加します。

## 変更内容

### 🔧 実装内容

1. **自動生成スクリプト** (`scripts/generate-changelog.mjs`)
   - Conventional Commitsに基づいてCHANGELOGを生成
   - 初期化と更新の両方に対応

2. **NPMスクリプト** (package.json)
   - `npm run changelog:init` - 初回CHANGELOG作成
   - `npm run changelog:update` - CHANGELOG更新
   - `npm run generate-changelog` - 汎用コマンド
   - `npm version` 実行時に自動でCHANGELOG更新

3. **GitHub Actions連携** (.github/workflows/release.yml)
   - リリース時に自動でCHANGELOG.mdを更新
   - 更新されたCHANGELOGをコミットに含める

4. **パッケージ配布** (package.json)
   - CHANGELOG.mdをnpmパッケージに含める

5. **ドキュメント更新** (PUBLISH.md)
   - CHANGELOG管理の手順を追加

### 🚀 使用方法

- **自動更新**: リリース時にGitHub Actionsが自動実行
- **手動更新**: `npm run changelog:update`
- **バージョンアップ時**: `npm version patch/minor/major` で自動更新

### 📋 生成されるCHANGELOG

- バージョン履歴の自動生成
- 機能追加、バグ修正、パフォーマンス改善の分類
- GitHubのPRやIssueへのリンク
- コミットハッシュへのリンク

## テスト

- [x] `npm run changelog:init` - 初回CHANGELOG作成
- [x] `npm run changelog:update` - CHANGELOG更新
- [x] 生成されたCHANGELOG.mdの内容確認

## 関連Issue

N/A

## 破壊的変更

なし

## チェックリスト

- [x] コードの品質チェック
- [x] テスト実行
- [x] ドキュメント更新
- [x] CHANGELOG.mdの生成確認